### PR TITLE
Fix: Correctly handle build numbers in semver versions

### DIFF
--- a/src/StubExecutable/StubExecutable.cpp
+++ b/src/StubExecutable/StubExecutable.cpp
@@ -40,13 +40,6 @@ wchar_t* FindOwnExecutableName()
 	return ret;
 }
 
-/**
- * Helper function to check if a character is a digit
- */
-bool isDigit(char c) {
-    return c >= '0' && c <= '9';
-}
-
 std::wstring FindLatestAppDir() 
 {
 	std::wstring ourDir;

--- a/src/StubExecutable/StubExecutable.cpp
+++ b/src/StubExecutable/StubExecutable.cpp
@@ -81,23 +81,26 @@ std::wstring FindLatestAppDir()
 			
 			// Check if both versions have build metadata
 			if (!thisVer.build().empty() && !acc.build().empty()) {
-				// Get the first digit of each build number
-				char thisFirstChar = thisVer.build()[0];
-				char accFirstChar = acc.build()[0];
-				
-				// If both are digits, compare them directly
-				if (isDigit(thisFirstChar) && isDigit(accFirstChar)) {
-					int thisDigit = thisFirstChar - '0';
-					int accDigit = accFirstChar - '0';
+				// Instead of just comparing the first digit, compare entire build strings as numbers
+				try {
+					// Parse build numbers as integers (assuming they're numeric)
+					int thisBuild = std::stoi(thisVer.build());
+					int accBuild = std::stoi(acc.build());
 					
-					// If this build digit is higher, use this version
-					if (thisDigit > accDigit) {
+					// If this build number is higher, use this version
+					if (thisBuild > accBuild) {
 						acc = thisVer;
 						acc_s = appVer;
 					}
 					
-					// Skip to next iteration
+					// Skip to next iteration since we've handled the comparison
 					continue;
+				}
+				catch (const std::invalid_argument&) {
+					// If build isn't a valid number, fall back to standard semver comparison
+				}
+				catch (const std::out_of_range&) {
+					// If build number is too large, fall back to standard semver comparison
 				}
 			}
 		}


### PR DESCRIPTION
When multiple versions with the same major.minor.patch but different build numbers (e.g., 1.2.3+4 and 1.2.3+5) are installed, ensure the stub executable launches the correct version by comparing build metadata numbers.

This fix enhances FindLatestAppDir() to:
- Identify versions with identical major.minor.patch numbers
- Extract and numerically compare their build metadata
- Select the version with the highest build number

Resolves issue where stub can't distinguish between versions that differ only by build number.